### PR TITLE
Add contributing guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+This project follows a simple code of conduct to foster a welcoming and respectful community.
+
+## Our Pledge
+
+In the interest of fostering an open and inclusive environment, we as contributors and maintainers pledge to make participation in our project and community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior by participants include:
+
+- Harassing comments or personal attacks
+- Trolling or insulting remarks
+- Publishing others' private information without consent
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and may remove or edit comments, commits, code, wiki edits, issues, and other contributions that do not align with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers through GitHub issues or private channels. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing Guide
+
+Thank you for considering contributing to this dataset repository. We welcome improvements to datasets, notebooks, and documentation.
+
+## Getting Started
+
+1. Fork the repository and create your feature branch.
+2. Make your changes with descriptive commit messages.
+3. Open a pull request against the `main` branch.
+
+Please open an issue first if you plan to contribute a new dataset or a major change.
+
+## Datasets
+
+- Use [DVC](https://dvc.org/) to track all dataset files.
+- Place raw data in the `data/` directory and commit the corresponding `.dvc` file.
+- Provide a short Markdown file describing the dataset and update `DATASET_TENSORS.md` or other summary documents as appropriate.
+- Ensure that your dataset is released under a license that permits redistribution. By contributing, you agree to release data under the CC0 1.0 Universal license.
+
+## Notebooks
+
+- Add example notebooks under the `examples/` directory.
+- Keep notebook outputs minimal. Clear large cell outputs before committing.
+- Use relative paths so notebooks work from a fresh clone after running `dvc pull`.
+
+## Documentation
+
+- Documentation is written in Markdown.
+- Keep a concise style and use relative links.
+- Update the table of contents or references in existing documents when adding new files.
+
+## Code Style
+
+Follow existing code and documentation conventions. Run linters or formatting tools if applicable. Make sure your changes build or run correctly before opening a pull request.
+
+Thank you for helping improve this project!

--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ The dataset files are released into the public domain under the CC0 1.0
 Universal license. Code and configuration contained in this repository
 remain available under the MIT License. See the [LICENSE](./LICENSE)
 file for full details.
+
+## Contributing
+
+We welcome contributions of new datasets, notebooks, and documentation.
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to
+get started. By participating in this project you agree to abide by our
+[Code of Conduct](./CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with instructions for contributing datasets, notebooks and docs
- add CODE_OF_CONDUCT.md establishing behavior standards
- link to these docs from README

## Testing
- `dvc status -c` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445fdb34148331b1be5a99049e5aa9