### PR TITLE
Add dataset helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ Datasets are tracked using DVC so that the repository remains lightweight. To fe
 
 After the command completes, the data described by the repository's DVC files will appear in the workspace.
 
+## Scripts
+
+Helper scripts for working with the example dataset are located in the `scripts/` directory.
+
+- `generate_demo_dataset.py` creates `data/tensors.npy` locally.
+- `download_data.sh` installs DVC and pulls the dataset from a configured remote.
+
+### Generating the demo dataset
+Run:
+```bash
+python scripts/generate_demo_dataset.py
+```
+
+### Downloading with DVC
+If you have configured a DVC remote, run:
+```bash
+./scripts/download_data.sh
+```
+
+
 ## Usage
 
 With the data downloaded you can import it in your experiments or notebooks. Example notebooks demonstrating basic usage are provided in the `notebooks/` directory.

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Fetch the dataset using DVC.
+# Assumes a DVC remote has been configured.
+set -euo pipefail
+pip install --quiet dvc
+
+dvc pull

--- a/scripts/generate_demo_dataset.py
+++ b/scripts/generate_demo_dataset.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Generate the example `tensors.npy` dataset.
+
+This script creates the small demo dataset used throughout the
+repository. The file will be written to `data/tensors.npy` relative to
+the repository root. Existing files will be overwritten.
+"""
+from pathlib import Path
+import numpy as np
+
+def main() -> None:
+    data_dir = Path(__file__).resolve().parent.parent / "data"
+    data_dir.mkdir(exist_ok=True)
+    arr = np.array([0.1, 0.2], dtype=np.float64)
+    out_path = data_dir / "tensors.npy"
+    np.save(out_path, arr)
+    print(f"Saved demo dataset to {out_path} ({arr.shape}, {arr.dtype})")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts to generate the demo dataset and download via DVC
- document usage of these scripts in README

## Testing
- `python scripts/generate_demo_dataset.py`
- `./scripts/download_data.sh` *(fails: Can't remove unsaved files without confirmation)*

------
https://chatgpt.com/codex/tasks/task_e_68446266d43483319e1412db64efead5