### PR TITLE
Remove invalid remote config

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,1 @@
 [core]
-    remote = localstore
-['remote "localstore"']
-    url = ../../dvc-storage

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Datasets are tracked using DVC so that the repository remains lightweight. To fe
    pip install dvc
    ```
 
-2. Configure your DVC remote (only needed once):
+2. Add your own DVC remote (the repository ships without one):
 
    ```bash
    dvc remote add -d storage <remote-url>


### PR DESCRIPTION
## Summary
- clean `.dvc/config` so no default remote is configured
- clarify README instructions for configuring your own DVC remote

## Testing
- `apt-get update && apt-get install -y tree`


------
https://chatgpt.com/codex/tasks/task_e_68446633bd008331964fda07f35d17a3