### PR TITLE
Add DVC pipeline for demo dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Run:
 ```bash
 python scripts/generate_demo_dataset.py
 ```
+To regenerate `data/tensors.npy` using DVC instead, run:
+```bash
+dvc repro
+```
 
 ### Downloading with DVC
 If you have configured a DVC remote, run:

--- a/data/tensors.npy.dvc
+++ b/data/tensors.npy.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: c70a8d0bd7ca7e0d0f375c43cee8202e
-  size: 144
-  hash: md5
-  path: tensors.npy

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,9 @@
+schema: '2.0'
+stages:
+  generate:
+    cmd: python scripts/generate_demo_dataset.py
+    outs:
+    - path: data/tensors.npy
+      hash: md5
+      md5: d34bfc7d8e4e84a29db0cf46560777e4
+      size: 144

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,5 @@
+stages:
+  generate:
+    cmd: python scripts/generate_demo_dataset.py
+    outs:
+      - data/tensors.npy


### PR DESCRIPTION
## Summary
- track tensors.npy with a `generate` stage in `dvc.yaml`
- document how to rerun the pipeline using `dvc repro`
- remove obsolete tracked file

## Testing
- `python -m py_compile scripts/generate_demo_dataset.py`
- `dvc repro`

------
https://chatgpt.com/codex/tasks/task_e_684468195664833198204186a7cca88b