### PR TITLE
Add extended tensor dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+data/

--- a/DATASET_TENSORS.md
+++ b/DATASET_TENSORS.md
@@ -1,12 +1,17 @@
 # Tensor Summary
 
-The dataset `tensors.npy` is tracked using DVC and contains numerical values used for examples in the project. The following table summarizes the tensors stored in this file.
+The datasets `tensors.npy` and `all_tensors.npz` are tracked using DVC and contain numerical values used for examples in the project. The following table summarizes the tensors stored in these files.
 
 | Tensor | Shape | Dtype | Description | Units |
 |-------|-------|-------|-------------|-------|
 | `tensors` | (2,) | float64 | Example numeric tensor for demonstration. | arbitrary |
+| `vector` | (10,) | float64 | Linearly spaced vector from 0 to 1. | arbitrary |
+| `matrix` | (5, 5) | float32 | Random matrix. | arbitrary |
+| `cube` | (4, 4, 4) | float32 | Random cube. | arbitrary |
+| `hypercube` | (2, 2, 2, 2) | float32 | Random hypercube. | arbitrary |
+| `sine_wave` | (50, 50) | float32 | 2D sine wave. | arbitrary |
 
-The file originates from the repository's `scripts/generate_demo_dataset.py` script. This script creates a small float64 vector `[0.1, 0.2]` with shape `(2,)` and saves it as `data/tensors.npy`. After pulling the data with DVC you can load the tensor in Python:
+The tensors originate from the repository's `scripts/generate_demo_dataset.py` script. This script creates the simple float64 vector `[0.1, 0.2]` and a collection of additional tensors which are stored in `data/all_tensors.npz`. After pulling the data with DVC you can load them in Python:
 
 ```python
 import numpy as np
@@ -14,4 +19,7 @@ import numpy as np
 tensor = np.load("data/tensors.npy")
 print(tensor.shape)  # (2,)
 print(tensor.dtype)  # float64
+
+all_tensors = np.load("data/all_tensors.npz")
+print(all_tensors["vector"].shape)
 ```

--- a/dvc.lock
+++ b/dvc.lock
@@ -7,3 +7,7 @@ stages:
       hash: md5
       md5: d34bfc7d8e4e84a29db0cf46560777e4
       size: 144
+    - path: data/all_tensors.npz
+      hash: md5
+      md5: 8482397e96cbe9260afd41581c87049e
+      size: 12004

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -3,3 +3,4 @@ stages:
     cmd: python scripts/generate_demo_dataset.py
     outs:
       - data/tensors.npy
+      - data/all_tensors.npz

--- a/scripts/generate_demo_dataset.py
+++ b/scripts/generate_demo_dataset.py
@@ -16,5 +16,26 @@ def main() -> None:
     np.save(out_path, arr)
     print(f"Saved demo dataset to {out_path} ({arr.shape}, {arr.dtype})")
 
+    # Create a richer collection of tensors demonstrating different shapes.
+    vector = np.linspace(0, 1, 10, dtype=np.float64)
+    matrix = np.random.rand(5, 5).astype(np.float32)
+    cube = np.random.rand(4, 4, 4).astype(np.float32)
+    hypercube = np.random.rand(2, 2, 2, 2).astype(np.float32)
+
+    x = np.linspace(-5, 5, 50)
+    y = np.linspace(-5, 5, 50)
+    grid_x, grid_y = np.meshgrid(x, y)
+    sine_wave = (np.sin(grid_x) * np.cos(grid_y)).astype(np.float32)
+
+    all_tensors_path = data_dir / "all_tensors.npz"
+    np.savez(all_tensors_path,
+             arr=arr,
+             vector=vector,
+             matrix=matrix,
+             cube=cube,
+             hypercube=hypercube,
+             sine_wave=sine_wave)
+    print(f"Saved extended dataset to {all_tensors_path}")
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- generate a richer NPZ dataset with several tensors
- update DVC configs for new output
- document the tensors and add data directory to .gitignore

## Testing
- `python scripts/generate_demo_dataset.py`
- `dvc status`


------
https://chatgpt.com/codex/tasks/task_e_68446c18dae48331a34a113b0c609b75